### PR TITLE
DB연결을 위한 Dockerfile 작성하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+###
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17
+ARG JAR_FILE=build/libs/app.jar
+COPY ${JAR_FILE} ./app.jar
+ENV TZ=Asia/Seoul
+ENTRYPOINT ["java", "-jar", "./app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ configurations {
 	}
 }
 
+bootJar {
+	archiveFileName = 'app.jar'
+}
+
 repositories {
 	mavenCentral()
 }

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,3 @@
+FROM mariadb:10
+
+ENV TZ=Asia/Seoul

--- a/database/config/mariadb.cnf
+++ b/database/config/mariadb.cnf
@@ -1,0 +1,13 @@
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4
+
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+skip-character-set-client-handshake
+
+[mysqldump]
+default-character-set=utf8mb4

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+services:
+  under-the-tree-database:
+    container_name: under-the-tree-database
+    build:
+      dockerfile: Dockerfile
+      context: ./database
+    image: ${DOCKER_USERNAME}/under-the-tree-database
+    environment:
+      - MARIADB_DATABASE=under_the_tree
+      - MARIADB_ROOT_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
+    volumes:
+      - ./database/config:/etc/mysql/conf.d
+    ports:
+      - "3306:3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  under-the-tree-database:
+    container_name: under-the-tree-database
+    build:
+      dockerfile: Dockerfile
+      context: ./database
+    image: ${DOCKER_USERNAME}/under-the-tree-database
+    environment:
+      - MARIADB_DATABASE=under_the_tree
+      - MARIADB_ROOT_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
+    volumes:
+      - ./database/config:/etc/mysql/conf.d
+    ports:
+      - "3306:3306"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,13 +1,28 @@
 spring:
+    profiles:
+        active: local #default
+        group:
+          local:
+              - common
+          prod:
+              - common
+---
+spring:
+    config:
+        active:
+            on-profile: common
+---
+spring:
+    config:
+        activate:
+            on-profile: local
     datasource:
-        hikari:
-            maximum-pool-size: 4
-        url: jdbc:mariadb://localhost:3306/under_the_tree
+        driver-class-name: org.mariadb.jdbc.Driver
+        url: jdbc:mariadb://localhost:3306/under_the_tree?allowPublicKeyRetrieval=true&useSSL=false
         username: ${SPRING_DATASOURCE_USERNAME}
         password: ${SPRING_DATASOURCE_PASSWORD}
-        driver-class-name: org.mariadb.jdbc.Driver
-spring.jpa:
-    hibernate:
-        dialect: org.hibernate.dialect.MariaDB
-        ddl-auto: update
-    show-sql: true
+    jpa:
+        hibernate:
+            dialect: org.hibernate.dialect.MariaDB
+            ddl-auto: update
+        show-sql: true


### PR DESCRIPTION
해당 pr에서는 MariaDB를 도커 컨테이너로 관리하기 위한 Dockerfile을 작성하였다. 유저 생성시에 가상 IP 주소로 인한 에러 생성이 불가할 수 있는데 이슈에 커멘트를 남겨놓았다.
This closes #3  